### PR TITLE
Add proxy option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jetbrains/intellij-http-client:231.8109.175
+FROM jetbrains/intellij-http-client:233.13135.65
 
 RUN apk add --no-cache bash
 

--- a/action-types.yml
+++ b/action-types.yml
@@ -28,6 +28,8 @@ inputs:
     separator: '\n'
     list-item:
       type: string
+  proxy:
+    type: string
 
   docker_mode:
     type: boolean

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,9 @@ inputs:
   private_env_variables:
     description: Private environment variables ('key=value')
     required: false
+  proxy:
+    description: Proxy setting in format 'scheme://login:password@host:port'
+    required: false
 
   docker_mode:
     description: Enables Docker mode. Treat 'localhost' as 'host.docker.internal'

--- a/intellij-http-client-action.sh
+++ b/intellij-http-client-action.sh
@@ -52,6 +52,9 @@ values options 'env-variables' "${INPUT_ENV_VARIABLES}"
 option options 'private-env-file' "${INPUT_PRIVATE_ENV_FILE}"
 values options 'private-env-variables' "${INPUT_PRIVATE_ENV_VARIABLES}"
 
+# https://youtrack.jetbrains.com/issue/IDEA-314789/IntelliJ-HTTP-Client-ignores-proxy-settings
+option options 'proxy' "${INPUT_PROXY}"
+
 flag options 'docker-mode' "${INPUT_DOCKER_MODE}"
 option options 'log-level' "${INPUT_LOG_LEVEL}"
 flag options 'report' "${INPUT_REPORT}"


### PR DESCRIPTION
The http client now allows for setting a proxy (https://youtrack.jetbrains.com/issue/IDEA-314789/IntelliJ-HTTP-Client-ignores-proxy-settings).

I updated the docker image as well, not sure why dependabot is not doing that